### PR TITLE
Revert rakefile to previous state

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,10 @@
 # encoding: utf-8
-require 'bundler/setup'
-require 'bundler/gem_tasks'
+begin
+  require 'bundler/setup'
+  require 'bundler/gem_tasks'
+rescue
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
 
 begin
   require 'rspec/core/rake_task'


### PR DESCRIPTION
Fixes (hopefully) error that arises when installing the gem. 

`Bundler::GemNotFound: Could not find gem 'rspec' in any of the gem sources listed in your Gemfile or available on this machine.`
